### PR TITLE
feat: add legal move generator to Bot base class

### DIFF
--- a/src/buffalo/bots.py
+++ b/src/buffalo/bots.py
@@ -1,12 +1,36 @@
 import random
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import List, Tuple
+
 from .board import Board, PieceType, Player, Position
 
 class Bot(ABC):
     def __init__(self, board: Board, player: Player) -> None:
         self.board = board
         self.player = player
+
+    def generate_legal_moves(self) -> List[Tuple[Position, Position]]:
+        """Generate all legal moves for this bot's player.
+
+        Uses the board's existing move validation logic to enumerate
+        moves without mutating the board state.
+        """
+
+        assert (
+            self.board.current_player == self.player
+        ), "Bot can only generate moves on its turn"
+
+        legal_moves: List[Tuple[Position, Position]] = []
+        for (from_x, from_y), piece in self.board.pieces.items():
+            if piece.player != self.player:
+                continue
+            for to_x in range(self.board.width):
+                for to_y in range(self.board.height):
+                    if self.board._is_valid_move(piece, from_x, from_y, to_x, to_y):
+                        legal_moves.append(
+                            (Position(from_x, from_y), Position(to_x, to_y))
+                        )
+        return legal_moves
 
     @abstractmethod
     def make_move(self) -> bool:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,27 @@
+import unittest
+
+from buffalo.board import Board, Position
+from buffalo.bots import NaiveBuffalo
+
+
+class TestBot(unittest.TestCase):
+    def test_generate_legal_moves_initial_buffalo(self):
+        board = Board()
+        bot = NaiveBuffalo(board)
+        moves = bot.generate_legal_moves()
+
+        self.assertEqual(len(moves), board.width)
+
+        expected = {
+            (x, 0, x, 1)
+            for x in range(board.width)
+        }
+        got = {
+            (from_pos.x, from_pos.y, to_pos.x, to_pos.y)
+            for from_pos, to_pos in moves
+        }
+        self.assertEqual(got, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `generate_legal_moves` to `Bot` leveraging board's validation logic
- cover buffalo move generation with a unit test

## Testing
- `PYTHONPATH=src python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a1531f6b88326821102bb79f8da27